### PR TITLE
Update PeterPortal docs to mention Next.js and Anteater API key search permissions

### DIFF
--- a/content/docs/contributor/peterportal/getting-started.mdx
+++ b/content/docs/contributor/peterportal/getting-started.mdx
@@ -88,7 +88,7 @@ To facilitate the development process, follow these steps:
    pnpm run dev
    ```
 
-   This command starts the backend Express server and the frontend Vite dev server. Visit the link printed in the console by Vite to view the application.
+   This command starts the backend Express server and the frontend Next.js dev server. Visit the link printed in the console by Next.js to view the application.
 
 Alternatively, you can run the backend and frontend separately by navigating to their respective directories and running `pnpm run dev` in separate terminal windows.
 

--- a/content/docs/contributor/peterportal/getting-started.mdx
+++ b/content/docs/contributor/peterportal/getting-started.mdx
@@ -59,7 +59,7 @@ This document will guide you through setting up the project on your local machin
 
 1. Inside the `api` directory, make a copy of the `.env.example` file and name it `.env`
 2. Add additional variables as needed for features requiring authentication or database access.
-   - You may want an Anteater API key; see [the Anteater API docs](https://docs.icssc.club/docs/developer/anteaterapi/keys-limits) for more information.
+   - You may want an Anteater API key to avoid rate limit issues; see [the Anteater API docs](https://docs.icssc.club/docs/developer/anteaterapi/keys-limits) for more information.
    - To test PeterPortal's search features locally, you'll need an Anteater API key with special search permissions. If you're working on a search-related issue, feel free to contact a project lead in the [Discord server](https://discord.gg/Zu8KZHERtJ) to get a search-enabled key.
 
 </Step>

--- a/content/docs/contributor/peterportal/getting-started.mdx
+++ b/content/docs/contributor/peterportal/getting-started.mdx
@@ -59,6 +59,8 @@ This document will guide you through setting up the project on your local machin
 
 1. Inside the `api` directory, make a copy of the `.env.example` file and name it `.env`
 2. Add additional variables as needed for features requiring authentication or database access.
+   - You may want an Anteater API key; see [the Anteater API docs](https://docs.icssc.club/docs/developer/anteaterapi/keys-limits) for more information.
+   - To test PeterPortal's search features locally, you'll need an Anteater API key with special search permissions. If you're working on a search-related issue, feel free to contact a project lead in the [Discord server](https://discord.gg/Zu8KZHERtJ) to get a search-enabled key.
 
 </Step>
 <Step>


### PR DESCRIPTION
PeterPortal docs were out of date as they mentioned Vite and we're now on Next.js. Also, as some contributors recently ran into issues with Anteater API key search permissions, added a note about that. The Discord link is sourced from AntAlmanac's getting started.

## Screenshots
| | |
| --- | --- |
| <img width="733" height="60" alt="image" src="https://github.com/user-attachments/assets/81a9cf38-7732-4622-8b53-9682b094c5c6" /> | <img width="776" height="181" alt="image" src="https://github.com/user-attachments/assets/a1c7f2fe-6ec5-4ecd-a9df-d805080087aa" /> |