### PR TITLE
Fix OpenNext redirects

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,8 +8,18 @@ const config = {
   async redirects() {
     return [
       {
+        source: "/docs/contributor/peterportal",
+        destination: "/docs/contributor/antalmanac-planner",
+        permanent: true,
+      },
+      {
         source: "/docs/contributor/peterportal/:path*",
         destination: "/docs/contributor/antalmanac-planner/:path*",
+        permanent: true,
+      },
+      {
+        source: "/docs/contributor/antalmanac",
+        destination: "/docs/contributor/antalmanac-scheduler",
         permanent: true,
       },
       {


### PR DESCRIPTION
Though the redirects in `next.config.mjs` worked in development, in production they have been broken when the path suffix is not included. This is due to a quirk of OpenNext improperly handling `:path*`.
- E.g. correctly, `/docs/contributor/peterportal/getting-started` -> `/docs/contributor/antalmanac-planner/getting-started`
- E.g. incorrectly, `/docs/contributor/peterportal` -> `/docs/contributor/antalmanac-planner/:path*`

Fixed by also including redirects for the path without a suffix. Testing can be done locally with `pnpm preview:worker`